### PR TITLE
Change action types from string to symbol's to ensure unique actions

### DIFF
--- a/src/stores/IAction.ts
+++ b/src/stores/IAction.ts
@@ -1,5 +1,5 @@
 interface IAction<T> {
-    type: string;
+    type: symbol;
     payload?: T;
     error?: boolean;
     meta?: any;

--- a/src/stores/loading/LoadingAction.ts
+++ b/src/stores/loading/LoadingAction.ts
@@ -2,7 +2,7 @@ import IAction from '../IAction';
 
 class LoadingAction {
 
-    public static readonly SET_LOADING: string = 'LoadingAction.SET_LOADING';
+    public static readonly SET_LOADING: symbol = Symbol('SET_LOADING');
 
     public static showLoader(isLoading: boolean): IAction<boolean> {
         return {

--- a/src/stores/meta/MetaAction.ts
+++ b/src/stores/meta/MetaAction.ts
@@ -3,7 +3,7 @@ import IAction from '../IAction';
 
 class MetaAction {
 
-    public static readonly SET_META: string = 'MetaAction.SET_META';
+    public static readonly SET_META: symbol = Symbol('SET_META');
 
     public static setMeta(meta: IMetaReducerState): IAction<IMetaReducerState>  {
         if (global.document) {

--- a/src/stores/user/UserAction.ts
+++ b/src/stores/user/UserAction.ts
@@ -2,9 +2,9 @@ import IAction from '../IAction';
 
 class UserAction {
 
-    public static readonly LOAD_USER: string = 'UserAction.LOAD_USER';
-    public static readonly LOAD_USER_SUCCESS: string = 'UserAction.LOAD_USER_SUCCESS';
-    public static readonly LOAD_USER_FAIL: string = 'UserAction.LOAD_USER_FAIL';
+    public static readonly LOAD_USER: symbol = Symbol('LOAD_USER');
+    public static readonly LOAD_USER_SUCCESS: symbol = Symbol('LOAD_USER_SUCCESS');
+    public static readonly LOAD_USER_FAIL: symbol = Symbol('LOAD_USER_FAIL');
 
     public static loadUser(): IAction<void> {
         return {

--- a/src/stores/user/UserSaga.ts
+++ b/src/stores/user/UserSaga.ts
@@ -13,7 +13,7 @@ class UserSaga {
         });
 
         const response: Response = yield fetch('https://randomuser.me/api/?inc=picture,name,email,phone,id,dob');
-        const type: string = (response.status === 200) ? UserAction.LOAD_USER_SUCCESS : UserAction.LOAD_USER_FAIL;
+        const type: symbol = (response.status === 200) ? UserAction.LOAD_USER_SUCCESS : UserAction.LOAD_USER_FAIL;
 
         let data: IUserReducerState = null;
 


### PR DESCRIPTION
Change action types from string to symbol's to ensure unique actions. Remove text namespace because it is no longer needed.